### PR TITLE
Add crystal

### DIFF
--- a/crystal/Dockerfile
+++ b/crystal/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:xenial
+
+RUN \
+  apt-get update && \
+  apt-get install -y apt-transport-https && \
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 09617FD37CC06B54 && \
+  echo "deb https://dist.crystal-lang.org/apt crystal main" > /etc/apt/sources.list.d/crystal.list && \
+  apt-get update && \
+  apt-get install -y crystal gcc pkg-config libssl-dev libxml2-dev libyaml-dev libgmp-dev git make && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /opt/crystal
+
+CMD ["bash"]


### PR DESCRIPTION
This PR adds [official Dockerfile](https://github.com/crystal-lang/crystal/blob/master/Dockerfile.release) for [The Crystal Programming Language](https://crystal-lang.org).

Crystal is a self-hosted programming language with friendly syntax, static type checking and modern stdlib. It compiles into efficient, easy-to-distribute native code.

![crystal](https://i.imgur.com/pHwLnIp.gif "crystal")